### PR TITLE
BE-109: Improve render performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2.1
+orbs:
+  react-native: react-native-community/react-native@1.2.1
+jobs:
+  test:
+    steps:
+      - run: yarn install
+      - run: yarn test:app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  test:
+  build:
     docker:
       - image: circleci/node:latest
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,5 @@ jobs:
     steps:
       - checkout
       - run: yarn install
-      - run: yarn test:app
+      - run: cd app && yarn install
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
-orbs:
-  react-native: react-native-community/react-native@1.2.1
 jobs:
   test:
+    docker:
+      - react-native-community/react-native@1.2.1
     steps:
       - run: yarn install
       - run: yarn test:app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,15 @@ jobs:
       - image: circleci/node:latest
     steps:
       - checkout
-      - run: yarn install
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
       - run: cd ~/BibleEngine/app && yarn install
       - run: cd ~/BibleEngine/app && yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - react-native-community/react-native@1.2.1
+      - image: react-native-community/react-native@1.2.1
     steps:
       - run: yarn install
       - run: yarn test:app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2.1
 jobs:
   build:
+    working_directory: ~/BibleEngine
     docker:
       - image: circleci/node:latest
     steps:
       - checkout
       - run: yarn install
-      - run: cd app && yarn install
-      - run: yarn test
+      - run: cd ~/BibleEngine/app && yarn install
+      - run: cd ~/BibleEngine/app && yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: react-native-community/react-native@1.2.1
+      - image: circleci/node:latest
     steps:
+      - checkout
       - run: yarn install
       - run: yarn test:app

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BibleEngine
 
+[![CircleCI](https://circleci.com/gh/tyndale/BibleEngine.svg?style=svg)](https://circleci.com/gh/tyndale/BibleEngine)
+
 **THIS IS A WORK IN PROGRESS** - don't use it in any kind of production code yet. Things will break.
 
 Having said that: Good you are here! Have a look at our [Project board](https://github.com/tyndale/BibleEngine/projects/1) to get an impression whats going on right now. Contributions welcome!

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -393,19 +393,18 @@ export default class App extends React.PureComponent<Props, State> {
     await Fonts.load();
     this.database = new Database(bibleDatabaseModule);
     const dbIsAvailable = await this.database.databaseIsAvailable();
-
-    const internetIsAvailable = await Network.internetIsAvailable();
-    if (!dbIsAvailable && (!internetIsAvailable || !Flags.REMOTE_ENABLED)) {
-      this.updateLoadingMessage(
-        'Updating database... \n\n(can take up to 30 seconds) \n\n Speed improvements coming soon! 🚀'
-      );
-      await this.database.setLocalDatabase();
-    } else if (Flags.REMOTE_ENABLED && internetIsAvailable && !dbIsAvailable) {
-      this.database.forceRemote = true;
-      this.database.setLocalDatabase();
-      this.pollForLocalDatabaseProgress();
-    } else if (dbIsAvailable) {
-      await this.database.setLocalBibleEngine();
+    if (!dbIsAvailable) {
+      const internetIsAvailable = await Network.internetIsAvailable();
+      if (!internetIsAvailable) {
+        this.updateLoadingMessage(
+          'Updating database... \n\n(can take up to 30 seconds) \n\n Speed improvements coming soon! 🚀'
+        );
+        await this.database.setLocalDatabase();
+      } else {
+        this.database.forceRemote = true;
+        this.database.setLocalDatabase();
+        this.pollForLocalDatabaseProgress();
+      }
     }
 
     let bookList = null;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -405,6 +405,8 @@ export default class App extends React.PureComponent<Props, State> {
         this.database.setLocalDatabase();
         this.pollForLocalDatabaseProgress();
       }
+    } else {
+      await this.database.setLocalBibleEngine();
     }
 
     let bookList = null;

--- a/app/src/ReadingView.tsx
+++ b/app/src/ReadingView.tsx
@@ -85,7 +85,6 @@ export default class ReadingView extends React.PureComponent<Props, State> {
         );
       }
     }
-    throw new Error(`Unrecognized content: ${JSON.stringify(content)}`);
   };
 
   renderSection = (content: IBibleContent): any => {

--- a/app/src/StrongsWord.tsx
+++ b/app/src/StrongsWord.tsx
@@ -53,19 +53,10 @@ export default class StrongsWord extends React.PureComponent<Props, State> {
 
   async componentDidMount() {
     this.mounted = true;
-    setTimeout(() => {
-      this.setDictionaryEntries(this.props.strongs);
-    }, 1000);
   }
 
   componentWillUnmount() {
     this.mounted = false;
-  }
-
-  async componentWillReceiveProps(nextProps: Props) {
-    setTimeout(() => {
-      this.setDictionaryEntries(nextProps.strongs);
-    }, 1000);
   }
 
   async setDictionaryEntries(strongs: string[]) {
@@ -89,6 +80,7 @@ export default class StrongsWord extends React.PureComponent<Props, State> {
 
   onPress = () => {
     this.setState({ ...this.state, popoverIsVisible: true });
+    this.setDictionaryEntries(this.props.strongs);
     setTimeout(() => {
       this.setState({
         ...this.state,

--- a/app/src/StrongsWord.tsx
+++ b/app/src/StrongsWord.tsx
@@ -55,7 +55,7 @@ export default class StrongsWord extends React.PureComponent<Props, State> {
     this.mounted = true;
     setTimeout(() => {
       this.setDictionaryEntries(this.props.strongs);
-    }, 100);
+    }, 1000);
   }
 
   componentWillUnmount() {
@@ -65,7 +65,7 @@ export default class StrongsWord extends React.PureComponent<Props, State> {
   async componentWillReceiveProps(nextProps: Props) {
     setTimeout(() => {
       this.setDictionaryEntries(nextProps.strongs);
-    }, 100);
+    }, 1000);
   }
 
   async setDictionaryEntries(strongs: string[]) {

--- a/core/src/BibleEngine.class.test.ts
+++ b/core/src/BibleEngine.class.test.ts
@@ -11,7 +11,7 @@ beforeAll(async () => {
     await sqlBible.addVersion(
         new BibleVersionEntity({
             uid: 'ESV',
-            title: 'English Standard Bible',
+            title: 'English Standard Version',
             language: 'en-US',
             chapterVerseSeparator: ':'
         })
@@ -23,7 +23,7 @@ test('BibleEngine version is set correctly', async () => {
     expect(versionEntity).toBeDefined();
     if (versionEntity) {
         expect(versionEntity.language).toEqual('en-US');
-        expect(versionEntity.title).toEqual('English Standard Bible');
+        expect(versionEntity.title).toEqual('English Standard Version');
         expect(versionEntity.uid).toEqual('ESV');
     }
 });

--- a/importers/package.json
+++ b/importers/package.json
@@ -29,6 +29,7 @@
         "@types/rimraf": "^2.0.2",
         "copyfiles": "^2.1.0",
         "jest": "24.5.0",
+        "sqlite3": "^4.1.0",
         "ts-jest": "24.0.0",
         "ts-node": "8.0.3",
         "tslint": "5.14.0",

--- a/importers/scripts/buildSqliteDatabase.ts
+++ b/importers/scripts/buildSqliteDatabase.ts
@@ -1,3 +1,4 @@
+import { V11nImporter } from './../src/v11n-rules/index';
 import { SwordImporter } from './../src/osis-sword-module/src/importer';
 import { StepLexiconImporter } from './../src/step-lexicon/importer';
 import { BeDatabaseCreator } from './../src/BeDatabaseCreator.class';
@@ -8,11 +9,11 @@ const run = async () => {
     database: 'bibles.db',
     dropSchema: true
   });
-
+  creator.addImporter(V11nImporter);
   creator.addImporter(SwordImporter, {
     sourcePath: 'src/osis-sword-module/data/ESV2016_th.zip'
   });
-  creator.addImporter(StepLexiconImporter)
+  creator.addImporter(StepLexiconImporter);
 
   await creator.createDatabase();
 };

--- a/importers/scripts/buildSqliteDatabase.ts
+++ b/importers/scripts/buildSqliteDatabase.ts
@@ -3,7 +3,6 @@ import { StepLexiconImporter } from './../src/step-lexicon/importer';
 import { BeDatabaseCreator } from './../src/BeDatabaseCreator.class';
 
 const run = async () => {
-    console.log(process.env.DATABASE_URL)
   const creator = new BeDatabaseCreator({
     type: 'sqlite',
     database: 'bibles.db',
@@ -12,16 +11,6 @@ const run = async () => {
 
   creator.addImporter(SwordImporter, {
     sourcePath: 'src/osis-sword-module/data/ESV2016_th.zip'
-  });
-  creator.addImporter(SwordImporter, {
-    sourcePath: 'src/osis-sword-module/data/ChiUns.zip',
-    versionMeta: {
-      title: 'Chinese Union Version',
-      uid: 'CUVs',
-      copyrightShort: 'Asia Bible Society 2013',
-      language: 'zh',
-      hasStrongs: true
-    }
   });
   creator.addImporter(StepLexiconImporter)
 

--- a/importers/src/osis-sword-module/src/importer.ts
+++ b/importers/src/osis-sword-module/src/importer.ts
@@ -27,7 +27,7 @@ export class SwordImporter extends BibleEngineImporter {
         const esvVersion = await this.bibleEngine.addVersion(
             new BibleVersionEntity({
                 uid: 'ESV',
-                title: 'English Standard Bible',
+                title: 'English Standard Version',
                 copyrightShort: '2001 by Crossway Bibles',
                 language: 'en-US',
                 chapterVerseSeparator: ':',

--- a/importers/src/osis-sword-module/tests/BibleEnginePlugin.test.ts.DISABLED
+++ b/importers/src/osis-sword-module/tests/BibleEnginePlugin.test.ts.DISABLED
@@ -21,7 +21,7 @@ const setupSqlBible = async () => {
     await sqlBible.addVersion(
         new BibleVersion({
             version: 'ESV',
-            title: 'English Standard Bible',
+            title: 'English Standard Version',
             language: 'en-US',
             chapterVerseSeparator: ':'
         })

--- a/importers/src/random-version/example.ts
+++ b/importers/src/random-version/example.ts
@@ -23,7 +23,7 @@ export const genDb = async () => {
     const esvVersion = await sqlBible.addVersion(
         new BibleVersionEntity({
             uid: 'ESV',
-            title: 'English Standard Bible',
+            title: 'English Standard Version',
             language: 'en-US',
             chapterVerseSeparator: ':'
         })

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "postinstall": "yarn run buildAll",
         "heroku": "node server/lib/heroku.js",
-        "buildAll": "yarn workspace @bible-engine/core run build && yarn workspace @bible-engine/importers run build && yarn workspace @bible-engine/server run generateApiClient && yarn workspace @bible-engine/server run build && yarn workspace @bible-engine/client run build"
+        "buildAll": "yarn workspace @bible-engine/core run build && yarn workspace @bible-engine/importers run build && yarn workspace @bible-engine/server run generateApiClient && yarn workspace @bible-engine/server run build && yarn workspace @bible-engine/client run build",
+        "test:app": "yarn workspace @bible-engine/core run test"
     },
     "workspaces": {
         "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3704,6 +3704,22 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
+node-pre-gyp@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
+  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
 node-pre-gyp@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
@@ -4888,6 +4904,15 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sqlite3@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.1.0.tgz#e051fb9c133be15726322a69e2e37ec560368380"
+  integrity sha512-RvqoKxq+8pDHsJo7aXxsFR18i+dU2Wp5o12qAJOV5LNcDt+fgJsc2QKKg3sIRfXrN9ZjzY1T7SNe/DFVqAXjaw==
+  dependencies:
+    nan "^2.12.1"
+    node-pre-gyp "^0.11.0"
+    request "^2.87.0"
 
 sqlstring@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
## Summary

Right now, the app feels a little sluggish, so I profiled every feature using `console.time`, and took the average value over 5 iterations:

For Genesis 1:
Baseline render performance: 1168 ms
Strongs:  396 ms
Internet check: 200 ms
Custom fonts: 161 ms
Version check: 100 ms
Loading screen animation: 80 ms
Cross references: 37 ms
Sidebar: no cost
Search: no cost

I also threw in a CI integration.

## Issue Link

https://github.com/tyndale/BibleEngine/issues/109