### PR TITLE
Add migrations to database, that work on mobile

### DIFF
--- a/core/src/BibleEngine.class.ts
+++ b/core/src/BibleEngine.class.ts
@@ -65,6 +65,7 @@ import {
     IBibleContentGroup,
     BiblePlaintext
 } from './models';
+import migrations from './migrations';
 
 export class NoDbConnectionError extends Error {
     constructor() {
@@ -103,8 +104,14 @@ export class BibleEngine {
             synchronize: true,
             logging: ['error'],
             name: 'bible-engine',
+            migrations,
             ...dbConfig
         }).then(conn => conn.manager);
+    }
+
+    async runMigrations() {
+        const entityManager = await this.pDB;
+        await entityManager.connection.runMigrations();
     }
 
     async addBook(book: IBibleBookEntity, entityManager?: EntityManager) {

--- a/core/src/migrations/1575603883533-PlaintextColumnOnVersions.ts
+++ b/core/src/migrations/1575603883533-PlaintextColumnOnVersions.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+const COLUMN_NAME = 'isPlaintext';
+
+export class PlaintextColumnOnVersions1575603883533 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        const column = new TableColumn({ name: COLUMN_NAME, type: 'integer', isNullable: true });
+        await queryRunner.addColumn('bible_version', column);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.dropColumn('bible_version', COLUMN_NAME);
+    }
+}

--- a/core/src/migrations/index.ts
+++ b/core/src/migrations/index.ts
@@ -1,0 +1,2 @@
+import { PlaintextColumnOnVersions1575603883533 } from './1575603883533-PlaintextColumnOnVersions';
+export default [PlaintextColumnOnVersions1575603883533];


### PR DESCRIPTION
### Why

A new column was added, `isPlaintext`, to the `bible_version` table.

In order to avoid errors on mobile, and circumvent need to entirely re-download database, migrations are cleaner, more predictable way to keep the database schema synced.

### How to Test

I tested this manually with STEP mobile app. It works.

There are a few caveats with running migrations on mobile device, namely, can't use glob pattern to capture everything in migrations directly, need to specify it in an index file.