### PR TITLE
Hotfix: properly catch migration failures in a database connection test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,12 @@ workflows:
                       - build_yarn
             - request_deploy_app:
                   type: approval
-                  requires:
-                    - test
-                    - test_migrations
             - deploy_expo:
                   context: expo-credentials
                   requires:
                     - request_deploy_app
+                    - test
+                    - test_migrations
             - deploy_ios:
                   context: expo-credentials
                   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,13 @@ jobs:
                       - yarn-modules-{{ checksum "yarn.lock" }}
             - run: yarn install --frozen-lockfile
             - run: cd app && yarn install --frozen-lockfile
-            - run: cd app && yarn expo login --non-interactive -u technical@tyndalehouse.com
-            - run: cd app && EXPO_DEBUG=true yarn expo publish --non-interactive --release-channel $(git rev-parse --short HEAD)
+            - run: yarn global add expo-cli
+            - run:
+                command: |
+                    export PATH="$PATH:$( yarn global bin )"
+                    cd app
+                    expo login --non-interactive -u technical@tyndalehouse.com
+                    EXPO_DEBUG=true expo publish --non-interactive --release-channel $(git rev-parse --short HEAD)
     deploy_android:
         macos:
             xcode: 11.3.0

--- a/app/app.json
+++ b/app/app.json
@@ -6,7 +6,7 @@
         "privacy": "unlisted",
         "sdkVersion": "36.0.0",
         "platforms": ["ios", "android"],
-        "version": "2.1.0",
+        "version": "2.1.1",
         "orientation": "portrait",
         "icon": "./assets/icon.png",
         "splash": {
@@ -22,11 +22,11 @@
         "ios": {
             "supportsTablet": true,
             "bundleIdentifier": "com.tyndale.step",
-            "buildNumber": "17"
+            "buildNumber": "18"
         },
         "android": {
             "package": "com.tyndale.stepbible",
-            "versionCode": 23
+            "versionCode": 24
         },
         "packagerOpts": {
             "sourceExts": ["ts", "tsx", "js"],

--- a/app/app.json
+++ b/app/app.json
@@ -22,11 +22,11 @@
         "ios": {
             "supportsTablet": true,
             "bundleIdentifier": "com.tyndale.step",
-            "buildNumber": "16"
+            "buildNumber": "17"
         },
         "android": {
             "package": "com.tyndale.stepbible",
-            "versionCode": 22
+            "versionCode": 23
         },
         "packagerOpts": {
             "sourceExts": ["ts", "tsx", "js"],

--- a/app/src/BibleStore.ts
+++ b/app/src/BibleStore.ts
@@ -324,7 +324,10 @@ class BibleStore {
   async testQueryWorks(): Promise<boolean> {
     let bibleEngine
     try {
-      bibleEngine = new BibleEngine(this.BIBLE_ENGINE_OPTIONS)
+      bibleEngine = new BibleEngine({
+        ...this.BIBLE_ENGINE_OPTIONS,
+        migrationsRun: false,
+      })
       await bibleEngine.runMigrations()
       const result = await bibleEngine.getDictionaryEntries(
         'H0001',


### PR DESCRIPTION
### Summary

The old app database didn't have migrations, so when running migrations from scratch, schema creation failed.

I fixed the connection test to not run migrations on startup, so that I can manually run the migrations and catch any ensuing errors.

### Test Plan

Tested locally with my old database, reproduced the error, and fixed it with this patch.