### PR TITLE
Fix incorrect strongs tag parsing

### DIFF
--- a/importers/package.json
+++ b/importers/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "lib/index.js",
     "scripts": {
-        "test": "yarn jest",
+        "test": "yarn jest --runInBand",
         "build": "rimraf ./lib && tsc && copyup './src/**/data/*' ./lib"
     },
     "dependencies": {

--- a/importers/src/bible/sword/src/OsisParser.ts
+++ b/importers/src/bible/sword/src/OsisParser.ts
@@ -103,14 +103,32 @@ export function getBibleEngineInputFromXML(bookXML: ChapterXML[]): IBibleContent
 function parseOpeningTag(node: OsisXmlNode, context: ParserContext) {
     context.currentNode = node;
     switch (node.name) {
-        case OsisXmlNodeName.XML:
-        case OsisXmlNodeName.WORD:
         case OsisXmlNodeName.CATCH_WORD:
-        case OsisXmlNodeName.REFERENCE:
+        case OsisXmlNodeName.FOREIGN_WORD:
         case OsisXmlNodeName.HIGHLIGHT:
+        case OsisXmlNodeName.LEMMA:
         case OsisXmlNodeName.LINE_GROUP:
         case OsisXmlNodeName.WORK:
-        case OsisXmlNodeName.CHAPTER: {
+        case OsisXmlNodeName.CHAPTER:
+        case OsisXmlNodeName.DATE:
+        case OsisXmlNodeName.DESCRIPTION:
+        case OsisXmlNodeName.DIVISION:
+        case OsisXmlNodeName.IDENTIFIER:
+        case OsisXmlNodeName.LANGUAGE:
+        case OsisXmlNodeName.MILESTONE:
+        case OsisXmlNodeName.NAME:
+        case OsisXmlNodeName.OSIS_HEADER:
+        case OsisXmlNodeName.PUBLISHER:
+        case OsisXmlNodeName.REF_SYSTEM:
+        case OsisXmlNodeName.REFERENCE:
+        case OsisXmlNodeName.REVISION_DESC:
+        case OsisXmlNodeName.RIGHTS:
+        case OsisXmlNodeName.TYPE:
+        case OsisXmlNodeName.VERSION_SCOPE:
+        case OsisXmlNodeName.WORD:
+        case OsisXmlNodeName.WORD_SEGMENT:
+        case OsisXmlNodeName.XML:
+        case OsisXmlNodeName.XML_ROOT: {
             // handled in parseTextNode or parseClosingTag, or ignored
             break;
         }

--- a/importers/src/bible/sword/src/OsisParser.ts
+++ b/importers/src/bible/sword/src/OsisParser.ts
@@ -475,9 +475,9 @@ function getStrongsNumbers(context: ParserContext): string[] {
         return [];
     }
     const lemma = context.currentNode!.attributes.lemma!;
-    const strongsNumbersString = lemma.replace(' ', '').replace('!', '');
+    const strongsNumbersString = lemma.split('strong:').join('')
     const strongsNumbers = strongsNumbersString
-        .split('strong:')
+        .split(' ')
         .filter(element => element)
         .map(strongsNum => normalizeStrongsNum(strongsNum));
     return strongsNumbers;

--- a/importers/src/bible/sword/src/OsisParser.ts
+++ b/importers/src/bible/sword/src/OsisParser.ts
@@ -103,7 +103,11 @@ function parseOpeningTag(node: OsisXmlNode, context: ParserContext) {
         case OsisXmlNodeName.WORD:
         case OsisXmlNodeName.CATCH_WORD:
         case OsisXmlNodeName.REFERENCE:
-        case OsisXmlNodeName.WORK: {
+        case OsisXmlNodeName.HIGHLIGHT:
+        case OsisXmlNodeName.LINE_GROUP:
+        case OsisXmlNodeName.WORK:
+        case OsisXmlNodeName.CHAPTER: {
+            // handled in parseTextNode or parseClosingTag, or ignored
             break;
         }
         case OsisXmlNodeName.NOTE: {

--- a/importers/src/bible/sword/src/OsisParser.ts
+++ b/importers/src/bible/sword/src/OsisParser.ts
@@ -17,6 +17,7 @@ import {
     IBibleContentGroup
 } from '@bible-engine/core';
 
+const prettifyXML = require('xml-formatter');
 const sax = require('sax');
 
 const DEBUG_OUTPUT_ENABLED = false;
@@ -65,13 +66,16 @@ export function getBibleEngineInputFromXML(bookXML: ChapterXML[]): IBibleContent
             );
 
             if (DEBUG_OUTPUT_ENABLED) {
-                const prettifyXML = require('xml-formatter');
                 console.log(prettifyXML(textWithoutUnusedTags));
                 console.log('********************************************');
             }
-
-            parser.write(textWithoutUnusedTags);
-            parser.close();
+            try {
+                parser.write(textWithoutUnusedTags);
+                parser.close();
+            } catch (error) {
+                console.error('Failed to parse this XML: ', prettifyXML(textWithoutUnusedTags))
+                throw error
+            }
         });
     }
 

--- a/importers/src/bible/sword/src/types.ts
+++ b/importers/src/bible/sword/src/types.ts
@@ -72,14 +72,13 @@ export type ParserContext = {
     currentCrossRefNode?: OsisXmlNode;
     crossRefs: IBibleCrossReference[];
     divineNameNode?: OsisXmlNode;
-    quoteNode?: OsisXmlNode;
     verseNum: number;
     notes: IBibleNote[];
     noteText: string;
     osisRef: string;
     psalmTitle?: OsisXmlNode;
     psalmTitleContents: IBibleContentPhrase[];
-    phrases: any;
+    phrases: any[];
     paragraph?: IBibleContentGroup<'paragraph'>;
     noteCount: number;
     title?: OsisXmlNode;

--- a/importers/src/bible/sword/src/types.ts
+++ b/importers/src/bible/sword/src/types.ts
@@ -81,6 +81,7 @@ export type ParserContext = {
     phrases: any[];
     paragraph?: IBibleContentGroup<'paragraph'>;
     noteCount: number;
+    quoteNode?: OsisXmlNode;
     title?: OsisXmlNode;
     titleSection: IBibleContentSection;
     titleSections: IBibleContentSection[];

--- a/importers/src/bible/sword/tests/OsisParser.test.ts
+++ b/importers/src/bible/sword/tests/OsisParser.test.ts
@@ -1,3 +1,4 @@
+import { IBibleContent } from '@bible-engine/core';
 import { getBibleEngineInputFromXML } from '../src/OsisParser';
 import { ChapterXML } from '../src/types';
 
@@ -54,26 +55,140 @@ describe('OsisParser', () => {
         });
     });
 
-    it(`Correctly parses multiple strongs numbers`, () => {
-        const VERSE = `
-            <w lemma="strong:H0168 strong:H0413 strong:H9033 strong:H9006">
-                tent
-            </w>
-        `
-        const XML = createSingleVerseXmlObject(VERSE)
-        const json: any = getBibleEngineInputFromXML(XML)
-        const strongs = json[0].contents[0].strongs
-        expect(strongs).toStrictEqual(['H0168', 'H0413', 'H9033', 'H9006'])
+    describe('Strongs number parsing', () => {
+        it(`Correctly parses multiple strongs numbers`, () => {
+            const VERSE = `
+                <w lemma='strong:H0168 strong:H0413 strong:H9033 strong:H9006'>
+                    tent
+                </w>
+            `
+            const XML = createSingleVerseXmlObject(VERSE)
+            const json: any = getBibleEngineInputFromXML(XML)
+            const strongs = json[0].contents[0].strongs
+            expect(strongs).toStrictEqual(['H0168', 'H0413', 'H9033', 'H9006'])
+        })
+        it(`Correctly parses a single strongs number`, () => {
+            const VERSE = `
+                <w lemma='strong:H0168'>
+                    tent
+                </w>
+            `
+            const XML = createSingleVerseXmlObject(VERSE)
+            const json: any = getBibleEngineInputFromXML(XML)
+            const strongs = json[0].contents[0].strongs
+            expect(strongs).toStrictEqual(['H0168'])
+        })
     })
-    it(`Correctly parses a single strongs number`, () => {
-        const VERSE = `
-            <w lemma="strong:H0168">
-                tent
-            </w>
-        `
-        const XML = createSingleVerseXmlObject(VERSE)
-        const json: any = getBibleEngineInputFromXML(XML)
-        const strongs = json[0].contents[0].strongs
-        expect(strongs).toStrictEqual(['H0168'])
+
+    describe('Quotation mark parsing', () => {
+        it(`Wraps quote blocks in quotation marks`, () => {
+            const VERSE = `
+                <w lemma='strong:H0430'>
+                    God
+                </w>
+                <w lemma='strong:H0559'>
+                    said
+                </w>
+                ,
+                <q level='1' marker='“'/>
+                Let there
+                <w lemma='strong:H1961'>
+                    be
+                </w>
+                <w lemma='strong:H0216'>
+                    light
+                </w>
+                ,
+                <q eID='01001003.1' level='1' marker='”'/>
+                and there was
+                <w lemma='strong:H0216 strong:H1961'>
+                    light
+                </w>
+            `
+            const EXPECTED_JSON: IBibleContent[] = [
+                {
+                    type: 'section',
+                    contents: [
+                        {
+                            type: 'phrase',
+                            content: 'God',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1,
+                            strongs: [
+                                'H0430'
+                            ]
+                        },
+                        {
+                            type: 'phrase',
+                            content: 'said,',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1,
+                            strongs: [
+                                'H0559'
+                            ]
+                        },
+                        {
+                            type: 'phrase',
+                            content: '“',
+                            skipSpace: 'after',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1
+                        },
+                        {
+                            type: 'phrase',
+                            content: 'Let there',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1
+                        },
+                        {
+                            type: 'phrase',
+                            content: 'be',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1,
+                            strongs: [
+                                'H1961'
+                            ]
+                        },
+                        {
+                            type: 'phrase',
+                            content: 'light,',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1,
+                            strongs: [
+                                'H0216'
+                            ]
+                        },
+                        {
+                            type: 'phrase',
+                            content: '”',
+                            skipSpace: 'before',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1
+                        },
+                        {
+                            type: 'phrase',
+                            content: 'and there was',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1
+                        },
+                        {
+                            type: 'phrase',
+                            content: 'light',
+                            versionChapterNum: 1,
+                            versionVerseNum: 1,
+                            strongs: [
+                                'H0216',
+                                'H1961'
+                            ]
+                        }
+                    ]
+                }
+            ]
+            const XML = createSingleVerseXmlObject(VERSE)
+            const json: any = getBibleEngineInputFromXML(XML)
+            expect(json).toStrictEqual(EXPECTED_JSON)
+        })
     })
+
+
 })

--- a/importers/src/bible/sword/tests/OsisParser.test.ts
+++ b/importers/src/bible/sword/tests/OsisParser.test.ts
@@ -129,14 +129,7 @@ describe('OsisParser', () => {
                         },
                         {
                             type: 'phrase',
-                            content: '“',
-                            skipSpace: 'after',
-                            versionChapterNum: 1,
-                            versionVerseNum: 1
-                        },
-                        {
-                            type: 'phrase',
-                            content: 'Let there',
+                            content: '“Let there',
                             versionChapterNum: 1,
                             versionVerseNum: 1
                         },
@@ -151,19 +144,12 @@ describe('OsisParser', () => {
                         },
                         {
                             type: 'phrase',
-                            content: 'light,',
+                            content: 'light,”',
                             versionChapterNum: 1,
                             versionVerseNum: 1,
                             strongs: [
                                 'H0216'
                             ]
-                        },
-                        {
-                            type: 'phrase',
-                            content: '”',
-                            skipSpace: 'before',
-                            versionChapterNum: 1,
-                            versionVerseNum: 1
                         },
                         {
                             type: 'phrase',

--- a/importers/src/bible/sword/tests/OsisParser.test.ts
+++ b/importers/src/bible/sword/tests/OsisParser.test.ts
@@ -4,6 +4,16 @@ import { ChapterXML } from '../src/types';
 describe('OsisParser', () => {
     const psalmsXML: ChapterXML = require('./Psa23EsvXmlResult.json');
 
+    const createSingleVerseXmlObject = (text: string): ChapterXML[] => ([
+        {
+            intro: '',
+            verses: [{
+                text,
+                verse: 1
+            }]
+        }
+    ])
+
     test('footnote associated with phrase that comes before, not after', async () => {
         const psalm23verse2 = [psalmsXML.verses[1]];
         const bookJson = getBibleEngineInputFromXML([{ intro: '', verses: psalm23verse2 }]);
@@ -43,4 +53,27 @@ describe('OsisParser', () => {
             expect(bookJson.length).toBeGreaterThan(0);
         });
     });
-});
+
+    it(`Correctly parses multiple strongs numbers`, () => {
+        const VERSE = `
+            <w lemma="strong:H0168 strong:H0413 strong:H9033 strong:H9006">
+                tent
+            </w>
+        `
+        const XML = createSingleVerseXmlObject(VERSE)
+        const json: any = getBibleEngineInputFromXML(XML)
+        const strongs = json[0].contents[0].strongs
+        expect(strongs).toStrictEqual(['H0168', 'H0413', 'H9033', 'H9006'])
+    })
+    it(`Correctly parses a single strongs number`, () => {
+        const VERSE = `
+            <w lemma="strong:H0168">
+                tent
+            </w>
+        `
+        const XML = createSingleVerseXmlObject(VERSE)
+        const json: any = getBibleEngineInputFromXML(XML)
+        const strongs = json[0].contents[0].strongs
+        expect(strongs).toStrictEqual(['H0168'])
+    })
+})

--- a/importers/src/shared/osisTypes.ts
+++ b/importers/src/shared/osisTypes.ts
@@ -61,6 +61,7 @@ export enum OsisXmlNodeName {
     HIGHLIGHT = 'hi',
     IDENTIFIER = 'identifier',
     LANGUAGE = 'language',
+    LEMMA = 'lemma',
     LINEBREAK = 'lb',
     LINE = 'l',
     LINE_GROUP = 'lg',


### PR DESCRIPTION
### Examples

https://photos.google.com/share/AF1QipNxu2wSqTGh5FqE1HkcrjhOdbNwt2ORK97H3Irzp_9s6Ejd9AVl_hCNayKwmAJQ_A?key=a0VuSGdGcmxLLUZKc3dFaklNbHJpN1AwVWlRcWNn

### Digging Deeper

eg Lev.23.38 "all your freewill offerings" is linked in ESV tagging with H5071 ('voluntariness')
The Hebrew tagging is: H3605#4=כֹּל=all/ H5071#4=נְדָבָה=voluntariness}/ H9026#6=Pp2m=your
In the App this is H5071 ('voluntariness) + H0026 ('Abigail') + H0002 ('father') + H0006 ('to perish) + H0005 ('Abagtha') + H0905 ('alone') + H3606 ('all')
What it should be is H5071  + H9026  + H3606  (not necessarily all of them or in that order)  

 eg Lev.23.4 "which...the time appointed for them" is linked in ESV tagging with H4150
The Hebrew tagging is : H9003#1=ב=in/ H4150#4=מוֹעֵד=meeting_§1_time_appointed/ H9028#6=Pp3m=their/ H0853#4=אֵת=obj./ H9038#6=Op3m=them
In the App this is H4150 ('meeting') + H0853 ('[Obj.]') + H0038 ('Abijam') + H9003 ('in|on|with')
What it should be is H4150 + H9028 + H0853 + H9038 + H9003  (not necessarily all of them or in that order)  

The only pattern I can see is that the App possibly has H0006 for H9006, H0026 for H9026 and H0038 for H9038. 